### PR TITLE
Initialize motorSpeed = 1023 (Default) in MI100 Firmware while MI100 pow...

### DIFF
--- a/lib/mi100.rb
+++ b/lib/mi100.rb
@@ -74,6 +74,7 @@ class Mi100
       retry unless retries_left < 0
       puts "Bluetooth connection failed."
       raise
+      self.speed
     end
 
   end


### PR DESCRIPTION
...er is ON.

After speed method is used, motorSpeed is kept the changed value until MI100 power is OFF.
