### PR TITLE
Issue #4 Add turn_led

### DIFF
--- a/lib/mi100.rb
+++ b/lib/mi100.rb
@@ -29,6 +29,7 @@ class Mi100
   CMD_TURN_LEFT       = "A"
   CMD_SET_SPEED       = "W"
   CMD_FREE_RAM        = "M"
+  CMD_TURN_LED_RGB    = "V"
 
   DEFAULT_SPEED           = 1023
   DEFAULT_MOVE_DURATION   = 300
@@ -76,6 +77,8 @@ class Mi100
       raise
     end
 
+    self.speed
+    self.turn_led 0,0,0
   end
 
   def close
@@ -188,6 +191,10 @@ class Mi100
     g = 100 if g > 100
     b = 100 if b > 100
     send_command_get_response "#{CMD_BLINK_LED},#{r.to_s},#{g.to_s},#{b.to_s},#{duration.to_s}"
+  end
+
+  def turn_led(r = 0, g = 0, b = 0)
+    send_command_get_response "#{CMD_TURN_LED_RGB},#{r.to_s},#{g.to_s},#{b.to_s}"
   end
 
   def stop

--- a/spec/mi100_spec.rb
+++ b/spec/mi100_spec.rb
@@ -8,6 +8,8 @@ describe Mi100 do
 
   before :each do
     Mi100.any_instance.stub(:initialize_serialport)
+    Mi100.any_instance.stub(:speed)
+    Mi100.any_instance.stub(:turn_led)
   end
 
   it 'should create the instance' do
@@ -179,6 +181,7 @@ describe Mi100 do
   it 'should send "W,pwm_value" on speed pwm_value' do
     Mi100.any_instance.stub(:send_command_get_response => [Mi100::CMD_SET_SPEED,1234])
     mi100 = Mi100.new "COM5"
+    Mi100.any_instance.unstub(:speed)
     expect(mi100.speed 500).to eq(["W",1234])
     expect(mi100).to have_received(:send_command_get_response).with("W,500")
   end
@@ -186,6 +189,7 @@ describe Mi100 do
   it 'should reset default speed' do
     Mi100.any_instance.stub(:send_command_get_response => [Mi100::CMD_SET_SPEED,1234])
     mi100 = Mi100.new "COM5"
+    Mi100.any_instance.unstub(:speed)
     expect(mi100.speed).to eq(["W",1234])
     expect(mi100).to have_received(:send_command_get_response).with("W,1023")
   end
@@ -197,11 +201,19 @@ describe Mi100 do
     expect(mi100).to have_received(:send_command_get_response).with("M")
   end
 
-  it 'should send "D,100, 50, 50,duration on blink 100,50,50,duration' do
+  it 'should send "D,100,50,50,duration on blink 100,50,50,duration' do
     Mi100.any_instance.stub(:send_command_get_response => [Mi100::CMD_BLINK_LED,1234])
     mi100 = Mi100.new "COM5"
     expect(mi100.blink 100,50,50,100).to eq(["D",1234])
     expect(mi100).to have_received(:send_command_get_response).with("D,100,50,50,100")
+  end
+
+  it 'should send "V,100,0,100 on turn_led 100,0,100' do
+    Mi100.any_instance.stub(:send_command_get_response => [Mi100::CMD_TURN_LED_RGB,1234])
+    mi100 = Mi100.new "COM5"
+    Mi100.any_instance.unstub(:turn_led)
+    expect(mi100.turn_led 100,0,100).to eq(["V",1234])
+    expect(mi100).to have_received(:send_command_get_response).with("V,100,0,100")
   end
 
   it 'should send "S" on stop' do


### PR DESCRIPTION
turn_led (r, g, b)  # 0; off, 0 < value <= 100;on.
using the command "V" on Mi100firmware.

LED点灯、LED消灯を可能にしました。
これで、内蔵LEDを使って、ライントレースができるようになりました。